### PR TITLE
Autocomplete extra custom field "affiliation"

### DIFF
--- a/server/studyspaces.py
+++ b/server/studyspaces.py
@@ -256,7 +256,8 @@ def book_room():
 
         email = contact.get("email")
         contact["custom"] = {}
-        for arg, field in [("q2533", "phone"), ("q2555", "size"), ("q2537", "size")]:
+        contact["custom"]["q3699"] = get_affiliation(email)
+        for arg, field in [("q2533", "phone"), ("q2555", "size"), ("q2537", "size"), ("q3699", "affiliation")]:
             try:
                 contact["custom"][arg] = request.form[field]
             except KeyError:
@@ -288,6 +289,17 @@ def book_room():
             user=user_id
         )
     return jsonify(resp)
+
+
+def get_affiliation(email):
+    if "wharton" in email:
+        return "Wharton"
+    elif "seas" in email:
+        return "SEAS"
+    elif "sas" in email:
+        return "SAS"
+    else:
+        return "Other"
 
 
 @app.route('/studyspaces/reservations', methods=['GET'])

--- a/tests/studyspaces_tests.py
+++ b/tests/studyspaces_tests.py
@@ -41,7 +41,7 @@ class StudySpacesApiTests(unittest.TestCase):
     def testStudyspaceBooking(self):
         with server.app.test_client() as c:
             # fake the actual booking
-            with mock.patch("penn.studyspaces.StudySpaces.book_room", return_value={"success": "booking placed", "results": []}):
+            with mock.patch("penn.studyspaces.StudySpaces.book_room", return_value={"success": "booking placed", "results": True}):
                 resp = c.post("/studyspaces/book", data={
                     "building": 1,
                     "room": 1,


### PR DESCRIPTION
Education Commons not requires an "affiliation" field. The server infers the affiliation from the email, choosing "Other" if the email does not contain "wharton," "sas," or "seas"

```
[
    {
        "id": 893,
        "name": "Education Commons Group Study Reservation",
        "fields": {
            "fname": {
                "label": "First Name",
                "type": "string",
                "required": true
            },
            "lname": {
                "label": "Last Name",
                "type": "string",
                "required": true
            },
            "email": {
                "label": "Email",
                "type": "string",
                "required": true
            },
            "q3699": {
                "id": 3699,
                "label": "Group affiliation",
                "type": "dropdown",
                "required": true,
                "options": [
                    "Design",
                    "GSE",
                    "SAS",
                    "SEAS",
                    "Wharton",
                    "Athletics",
                    "Penn Libraries",
                    "PSOM / CHOP / UPHS",
                    "Other"
                ]
            },
            "q2537": {
                "id": 2537,
                "label": "Size of Group",
                "type": "dropdown",
                "required": true,
                "options": [
                    "2-3",
                    "4-5",
                    "6-7",
                    "8-10"
                ]
            }
        }
    }
]
```