### PR TITLE
Added Homepage GSR Reservation Timeouts

### DIFF
--- a/server/account.py
+++ b/server/account.py
@@ -226,7 +226,7 @@ def get_potential_email(json):
                 elif "LPS" in code:
                     email = "{}@sas.upenn.edu".format(pennkey)
                 elif "SP2" in code:
-                    email = "{}@upenn.edu".format(pennkey)   
+                    email = "{}@upenn.edu".format(pennkey)
     return email
 
 

--- a/server/homepage.py
+++ b/server/homepage.py
@@ -171,7 +171,7 @@ def get_reservations_cell(user, sessionid):
     # returns a cell with the user's reservations, weighted extremely high to appear at the top
     # returns None if user has no reservations
     try:
-        reservations = get_reservations(user.email, sessionid, 1)
+        reservations = get_reservations(user.email, sessionid, 1, 2)
         if reservations:
             return HomeCell("reservations", reservations, 1000)
         else:

--- a/server/studyspaces.py
+++ b/server/studyspaces.py
@@ -339,11 +339,11 @@ def get_reservations_endpoint():
         return jsonify({"error": str(e)}), 400
 
 
-def get_reservations(email, sessionid, libcal_search_span):
+def get_reservations(email, sessionid, libcal_search_span, timeout=20):
     reservations = []
     if sessionid:
         try:
-            gsr_reservations = wharton.get_reservations(sessionid)
+            gsr_reservations = wharton.get_reservations(sessionid, timeout)
             timezone = wharton.get_dst_gmt_timezone()
 
             for res in gsr_reservations:
@@ -393,9 +393,10 @@ def get_reservations(email, sessionid, libcal_search_span):
             reservations.extend(gsr_reservations)
 
         except APIError as e:
-            raise e
+            pass
 
     if email:
+        confirmed_reservations = []
         try:
             def is_not_cancelled_in_db(booking_id):
                 booking = StudySpacesBooking.query.filter_by(booking_id=booking_id).first()
@@ -404,45 +405,44 @@ def get_reservations(email, sessionid, libcal_search_span):
             now = datetime.datetime.now()
             dateFormat = "%Y-%m-%d"
             i = 0
-            confirmed_reservations = []
             while len(confirmed_reservations) == 0 and i < libcal_search_span:
                 date = now + datetime.timedelta(days=i)
                 dateStr = datetime.datetime.strftime(date, dateFormat)
-                libcal_reservations = studyspaces.get_reservations(email, dateStr)
+                libcal_reservations = studyspaces.get_reservations(email, dateStr, timeout)
                 confirmed_reservations = [res for res in libcal_reservations if (res["status"] == "Confirmed"
                                           and datetime.datetime.strptime(res["toDate"][:-6], "%Y-%m-%dT%H:%M:%S") >= now)]
                 confirmed_reservations = [res for res in confirmed_reservations if is_not_cancelled_in_db(res["bookId"])]
                 i += 1
 
-            # Fetch reservations in database that are not being returned by API
-            db_bookings = StudySpacesBooking.query.filter_by(email=email)
-            db_booking_ids = [str(x.booking_id) for x in db_bookings if x.end
-                              and x.end > now
-                              and not str(x.booking_id).isdigit()
-                              and not x.is_cancelled]
-            reservation_ids = [x["bookId"] for x in confirmed_reservations]
-            missing_booking_ids = list(set(db_booking_ids) - set(reservation_ids))
-            if missing_booking_ids:
-                missing_bookings_str = ",".join(missing_booking_ids)
-                missing_reservations = studyspaces.get_reservations_for_booking_ids(missing_bookings_str)
-                confirmed_missing_reservations = [res for res in missing_reservations if res["status"] == "Confirmed"]
-                confirmed_reservations.extend(confirmed_missing_reservations)
-
-            for res in confirmed_reservations:
-                res["service"] = "libcal"
-                res["booking_id"] = res["bookId"]
-                res["room_id"] = res["eid"]
-                res["gid"] = res["cid"]
-                del res["bookId"]
-                del res["eid"]
-                del res["cid"]
-                del res["status"]
-                del res["email"]
-                del res["firstName"]
-                del res["lastName"]
-
         except APIError as e:
-            raise e
+            pass
+
+        # Fetch reservations in database that are not being returned by API
+        db_bookings = StudySpacesBooking.query.filter_by(email=email)
+        db_booking_ids = [str(x.booking_id) for x in db_bookings if x.end
+                          and x.end > now
+                          and not str(x.booking_id).isdigit()
+                          and not x.is_cancelled]
+        reservation_ids = [x["bookId"] for x in confirmed_reservations]
+        missing_booking_ids = list(set(db_booking_ids) - set(reservation_ids))
+        if missing_booking_ids:
+            missing_bookings_str = ",".join(missing_booking_ids)
+            missing_reservations = studyspaces.get_reservations_for_booking_ids(missing_bookings_str)
+            confirmed_missing_reservations = [res for res in missing_reservations if res["status"] == "Confirmed"]
+            confirmed_reservations.extend(confirmed_missing_reservations)
+
+        for res in confirmed_reservations:
+            res["service"] = "libcal"
+            res["booking_id"] = res["bookId"]
+            res["room_id"] = res["eid"]
+            res["gid"] = res["cid"]
+            del res["bookId"]
+            del res["eid"]
+            del res["cid"]
+            del res["status"]
+            del res["email"]
+            del res["firstName"]
+            del res["lastName"]
 
         room_ids = ",".join(list(set([str(x["room_id"]) for x in confirmed_reservations])))
         if room_ids:

--- a/server/studyspaces.py
+++ b/server/studyspaces.py
@@ -392,7 +392,7 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
 
             reservations.extend(gsr_reservations)
 
-        except APIError as e:
+        except APIError:
             pass
 
     if email:
@@ -414,7 +414,7 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                 confirmed_reservations = [res for res in confirmed_reservations if is_not_cancelled_in_db(res["bookId"])]
                 i += 1
 
-        except APIError as e:
+        except APIError:
             pass
 
         # Fetch reservations in database that are not being returned by API


### PR DESCRIPTION
Added 2 sec timeout for getting someone's reservations to avoid excessively long homepage load times. If it takes more than 2 sec to reach Wharton or libcal reservation endpoint, server stops and returns 0 reservations, so no reservation cell will show up.