### PR TITLE
Get dining dollar transaction history

### DIFF
--- a/server/dining/transactions.py
+++ b/server/dining/transactions.py
@@ -50,8 +50,8 @@ def get_dining_dollar_transactions():
         return jsonify({'success': False, 'error': str(e)}), 400
 
     transactions = sqldb.session.query(DiningTransaction) \
-                                    .filter_by(account_id=account.id) \
-                                    .order_by(DiningTransaction.date.desc())
+                                .filter_by(account_id=account.id) \
+                                .order_by(DiningTransaction.date.desc())
 
     results = []
 

--- a/server/dining/transactions.py
+++ b/server/dining/transactions.py
@@ -40,3 +40,28 @@ def save_dining_dollar_transactions():
     sqldb.session.commit()
 
     return jsonify({'success': True, 'error': None})
+
+
+@app.route('/dining/transactions', methods=['GET'])
+def get_dining_dollar_transactions():
+    try:
+        account = Account.get_account()
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
+    transactions = sqldb.session.query(DiningTransaction) \
+                                    .filter_by(account_id=account.id) \
+                                    .order_by(DiningTransaction.date.desc())
+
+    results = []
+
+    for transaction in transactions:
+        date = datetime.datetime.strftime(transaction.date, '%Y-%m-%dT%H:%M:%S')
+        results.append({
+            'date': date,
+            'description': transaction.description,
+            'amount': transaction.amount,
+            'balance': transaction.balance,
+        })
+
+    return jsonify({'results': results})


### PR DESCRIPTION
The endpoint is ```/dining/transactions". Simply pass in the account ID and receive the history in the following format:

```
{
  "results": [
    {
      "amount": -9.02,
      "balance": 295.02,
      "date": "2019-10-29T12:28:00",
      "description": "Penn Pi Mobile"
    },
    {
      "amount": -5.2,
      "balance": 304.04,
      "date": "2019-10-29T10:32:00",
      "description": "Starbucks2Sequoia"
    },
    {
      "amount": -20.9,
      "balance": 309.24,
      "date": "2019-10-28T17:03:00",
      "description": "0142ResidentialDining - Charge"
    },
    ....
}
```