### PR TITLE
EST/GMT Fix

### DIFF
--- a/server/calendar3year.py
+++ b/server/calendar3year.py
@@ -1,8 +1,8 @@
 import datetime
 import re
-from pytz import timezone
 
 from flask import jsonify
+from pytz import timezone
 
 from server import app
 from server.base import cache_get

--- a/server/calendar3year.py
+++ b/server/calendar3year.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from pytz import timezone
 
 from flask import jsonify
 
@@ -40,7 +41,9 @@ def pull_todays_calendar():
     """Returns array of events which are 2 weeks away
     from today
     """
-    today = datetime.datetime.now().date()
+    est = timezone('EST')
+    now = datetime.datetime.now(est)
+    today = now.date()
     return pull_calendar(today)
 
 
@@ -49,7 +52,9 @@ def pull_today():
     """Returns JSON object with all events 2 weeks from the
     current date.
     """
-    today = datetime.datetime.now().date()
+    est = timezone('EST')
+    now = datetime.datetime.now(est)
+    today = now.date()
     return pull_calendar_response(today)
 
 

--- a/server/laundry.py
+++ b/server/laundry.py
@@ -1,8 +1,8 @@
 import calendar
 import datetime
-from pytz import timezone
 
 from flask import g, jsonify, request
+from pytz import timezone
 from requests.exceptions import HTTPError
 from sqlalchemy import Integer, cast, exists, func
 

--- a/server/laundry.py
+++ b/server/laundry.py
@@ -1,5 +1,6 @@
 import calendar
 import datetime
+from pytz import timezone
 
 from flask import g, jsonify, request
 from requests.exceptions import HTTPError
@@ -22,7 +23,8 @@ def all_halls():
 
 @app.route('/laundry/rooms/<hall_ids>', methods=['GET'])
 def get_rooms(hall_ids):
-    date = datetime.datetime.now()
+    est = timezone('EST')
+    date = datetime.datetime.now(est)
     halls = [int(x) for x in hall_ids.split(',')]
     output = {'rooms': []}
     for hall in halls:
@@ -70,7 +72,8 @@ def safe_division(a, b):
 
 @app.route('/laundry/usage/<int:hall_no>')
 def usage_shortcut(hall_no):
-    now = datetime.datetime.now()
+    est = timezone('EST')
+    now = datetime.datetime.now(est)
     return usage(hall_no, now.year, now.month, now.day)
 
 
@@ -154,7 +157,8 @@ def save_data():
     """Retrieves current laundry info and saves it into the database."""
 
     # get the number of minutes since midnight
-    now = datetime.datetime.now()
+    est = timezone('EST')
+    now = datetime.datetime.now(est)
     midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
     date = now.date()
     time = round((now - midnight).seconds / 60)

--- a/server/portal/account.py
+++ b/server/portal/account.py
@@ -198,7 +198,7 @@ def verify_account_email_token():
     else:
         account_email.verified = True
         est = timezone('EST')
-        now = datetime.now(est)
+        now = datetime.now(est).replace(tzinfo=None)
         upcoming_posts = Post.query.filter(Post.account == account_email.account).filter(Post.end_date >= now).all()
         for post in upcoming_posts:
             tester = PostTester(post=post.id, email=account_email.email)

--- a/server/portal/account.py
+++ b/server/portal/account.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime, timedelta
-from pytz import timezone
 
 from flask import jsonify, redirect, request
+from pytz import timezone
 from sqlalchemy import exists
 
 from server import app, bcrypt, sqldb

--- a/server/portal/account.py
+++ b/server/portal/account.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
+from pytz import timezone
 
 from flask import jsonify, redirect, request
 from sqlalchemy import exists
@@ -196,7 +197,8 @@ def verify_account_email_token():
         return jsonify({'error': 'This email has already been verified for this account.'})
     else:
         account_email.verified = True
-        now = datetime.now()
+        est = timezone('EST')
+        now = datetime.now(est)
         upcoming_posts = Post.query.filter(Post.account == account_email.account).filter(Post.end_date >= now).all()
         for post in upcoming_posts:
             tester = PostTester(post=post.id, email=account_email.email)

--- a/server/portal/posts.py
+++ b/server/portal/posts.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from pytz import timezone
 
 from flask import jsonify, request
+from pytz import timezone
 from sqlalchemy import and_, desc, func
 
 from server import app, sqldb

--- a/server/portal/posts.py
+++ b/server/portal/posts.py
@@ -189,7 +189,7 @@ def get_post_json(post):
 
 def get_posts_for_account(account):
     est = timezone('EST')
-    now = datetime.now(est)
+    now = datetime.now(est).replace(tzinfo=None)
     post_arr = []
 
     if not account:
@@ -221,7 +221,7 @@ def get_posts_for_account(account):
 def get_posts_where_tester(account):
     # Find any posts that have yet to end for which this account is a tester
     est = timezone('EST')
-    now = datetime.now(est)
+    now = datetime.now(est).replace(tzinfo=None)
     post_testers = sqldb.session.query(Post) \
                                 .join(PostTester, isouter=True, full=False) \
                                 .filter(Post.end_date >= now) \
@@ -239,7 +239,7 @@ def get_posts_where_tester(account):
 def get_email_targeted_posts(account):
     # Find running posts that have yet to end for which this account is in target email list
     est = timezone('EST')
-    now = datetime.now(est)
+    now = datetime.now(est).replace(tzinfo=None)
     posts_emails = sqldb.session.query(Post) \
                                 .join(PostTargetEmail, isouter=True, full=False) \
                                 .filter(Post.start_date <= now) \
@@ -258,7 +258,7 @@ def get_email_targeted_posts(account):
 
 def get_filtered_posts(account):
     est = timezone('EST')
-    now = datetime.now(est)
+    now = datetime.now(est).replace(tzinfo=None)
     majr_filters = sqldb.session.query(SchoolMajorAccount.major, SchoolMajorAccount.expected_grad, School.code) \
                                 .join(School, School.id == SchoolMajorAccount.school_id) \
                                 .filter(SchoolMajorAccount.account_id == account.id) \

--- a/server/portal/posts.py
+++ b/server/portal/posts.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pytz import timezone
 
 from flask import jsonify, request
 from sqlalchemy import and_, desc, func
@@ -187,7 +188,8 @@ def get_post_json(post):
 
 
 def get_posts_for_account(account):
-    now = datetime.now()
+    est = timezone('EST')
+    now = datetime.now(est)
     post_arr = []
 
     if not account:
@@ -218,7 +220,8 @@ def get_posts_for_account(account):
 
 def get_posts_where_tester(account):
     # Find any posts that have yet to end for which this account is a tester
-    now = datetime.now()
+    est = timezone('EST')
+    now = datetime.now(est)
     post_testers = sqldb.session.query(Post) \
                                 .join(PostTester, isouter=True, full=False) \
                                 .filter(Post.end_date >= now) \
@@ -235,7 +238,8 @@ def get_posts_where_tester(account):
 
 def get_email_targeted_posts(account):
     # Find running posts that have yet to end for which this account is in target email list
-    now = datetime.now()
+    est = timezone('EST')
+    now = datetime.now(est)
     posts_emails = sqldb.session.query(Post) \
                                 .join(PostTargetEmail, isouter=True, full=False) \
                                 .filter(Post.start_date <= now) \
@@ -253,7 +257,8 @@ def get_email_targeted_posts(account):
 
 
 def get_filtered_posts(account):
-    now = datetime.now()
+    est = timezone('EST')
+    now = datetime.now(est)
     majr_filters = sqldb.session.query(SchoolMajorAccount.major, SchoolMajorAccount.expected_grad, School.code) \
                                 .join(School, School.id == SchoolMajorAccount.school_id) \
                                 .filter(SchoolMajorAccount.account_id == account.id) \

--- a/server/studyspaces/cancel.py
+++ b/server/studyspaces/cancel.py
@@ -16,6 +16,7 @@ def cancel_room():
     try:
         user = User.get_user()
     except ValueError as err:
+        print(err)
         return jsonify({'error': str(err)})
 
     booking_id = request.form.get('booking_id')

--- a/server/studyspaces/models.py
+++ b/server/studyspaces/models.py
@@ -1,6 +1,12 @@
-import datetime
+from datetime import datetime
+from pytz import timezone
 
 from server import sqldb
+
+
+def get_est_date():
+    est = timezone('EST')
+    return datetime.now(est)
 
 
 class StudySpacesBooking(sqldb.Model):
@@ -8,7 +14,7 @@ class StudySpacesBooking(sqldb.Model):
     account = sqldb.Column(sqldb.VARCHAR(255), sqldb.ForeignKey('account.id'), nullable=True)
     user = sqldb.Column(sqldb.Integer, sqldb.ForeignKey('user.id'), nullable=True)
     booking_id = sqldb.Column(sqldb.Text, nullable=True)
-    date = sqldb.Column(sqldb.DateTime, default=datetime.datetime.now)
+    date = sqldb.Column(sqldb.DateTime, default=get_est_date)
     lid = sqldb.Column(sqldb.Integer, nullable=True)
     rid = sqldb.Column(sqldb.Integer, nullable=True)
     email = sqldb.Column(sqldb.Text, nullable=True)

--- a/server/studyspaces/models.py
+++ b/server/studyspaces/models.py
@@ -6,7 +6,7 @@ from server import sqldb
 
 def get_est_date():
     est = timezone('EST')
-    return datetime.now(est)
+    return datetime.now(est).replace(tzinfo=None)
 
 
 class StudySpacesBooking(sqldb.Model):

--- a/server/studyspaces/models.py
+++ b/server/studyspaces/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from pytz import timezone
 
 from server import sqldb

--- a/server/studyspaces/notifications.py
+++ b/server/studyspaces/notifications.py
@@ -1,5 +1,6 @@
 import math
 from datetime import datetime, timedelta
+from pytz import timezone
 
 from flask import jsonify
 from sqlalchemy import and_, not_
@@ -32,7 +33,8 @@ def run_query():
     # 4) Have not been sent a reminder yet
     # 5) Have an associated account with an iOS push notification token
 
-    now = datetime.now()
+    est = timezone('EST')
+    now = datetime.now(est)
     check_start_date = now + timedelta(minutes=10)
     get_gsr = StudySpacesBooking.query \
                                 .filter(StudySpacesBooking.start <= check_start_date) \

--- a/server/studyspaces/notifications.py
+++ b/server/studyspaces/notifications.py
@@ -1,8 +1,8 @@
 import math
 from datetime import datetime, timedelta
-from pytz import timezone
 
 from flask import jsonify
+from pytz import timezone
 from sqlalchemy import and_, not_
 
 from server import app, sqldb

--- a/server/studyspaces/notifications.py
+++ b/server/studyspaces/notifications.py
@@ -34,7 +34,7 @@ def run_query():
     # 5) Have an associated account with an iOS push notification token
 
     est = timezone('EST')
-    now = datetime.now(est)
+    now = datetime.now(est).replace(tzinfo=None)
     check_start_date = now + timedelta(minutes=10)
     get_gsr = StudySpacesBooking.query \
                                 .filter(StudySpacesBooking.start <= check_start_date) \

--- a/server/studyspaces/reservations.py
+++ b/server/studyspaces/reservations.py
@@ -1,4 +1,5 @@
-import datetime
+from datetime import datetime
+from pytz import timezone
 
 from flask import jsonify, request
 from penn.base import APIError
@@ -51,8 +52,8 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                 res['info'] = None
                 del res['location']
 
-                date = datetime.datetime.strptime(res['date'], '%b %d, %Y')
-                date_str = datetime.datetime.strftime(date, '%Y-%m-%d')
+                date = datetime.strptime(res['date'], '%b %d, %Y')
+                date_str = datetime.strftime(date, '%Y-%m-%d')
 
                 if res['startTime'] == 'midnight':
                     res['fromDate'] = date_str + 'T00:00:00-{}'.format(timezone)
@@ -61,25 +62,25 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                 else:
                     start_str = res['startTime'].replace('.', '').upper()
                     try:
-                        start_time = datetime.datetime.strptime(start_str, '%I:%M %p')
+                        start_time = datetime.strptime(start_str, '%I:%M %p')
                     except ValueError:
-                        start_time = datetime.datetime.strptime(start_str, '%I %p')
-                    start_str = datetime.datetime.strftime(start_time, '%H:%M:%S')
+                        start_time = datetime.strptime(start_str, '%I %p')
+                    start_str = datetime.strftime(start_time, '%H:%M:%S')
                     res['fromDate'] = '{}T{}-{}'.format(date_str, start_str, timezone)
 
                 if res['endTime'] == 'midnight':
                     date += datetime.timedelta(days=1)
-                    date_str = datetime.datetime.strftime(date, '%Y-%m-%d')
+                    date_str = datetime.strftime(date, '%Y-%m-%d')
                     res['toDate'] = date_str + 'T00:00:00-{}'.format(timezone)
                 elif res['endTime'] == 'noon':
                     res['toDate'] = date_str + 'T12:00:00-{}'.format(timezone)
                 else:
                     end_str = res['endTime'].replace('.', '').upper()
                     try:
-                        end_time = datetime.datetime.strptime(end_str, '%I:%M %p')
+                        end_time = datetime.strptime(end_str, '%I:%M %p')
                     except ValueError:
-                        end_time = datetime.datetime.strptime(end_str, '%I %p')
-                    end_str = datetime.datetime.strftime(end_time, '%H:%M:%S')
+                        end_time = datetime.strptime(end_str, '%I %p')
+                    end_str = datetime.strftime(end_time, '%H:%M:%S')
                     res['toDate'] = '{}T{}-{}'.format(date_str, end_str, timezone)
 
                 del res['date']
@@ -98,16 +99,17 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                 booking = StudySpacesBooking.query.filter_by(booking_id=booking_id).first()
                 return not (booking and booking.is_cancelled)
 
-            now = datetime.datetime.now()
+            est = timezone('EST')
+            now = datetime.now(est)
             dateFormat = '%Y-%m-%d'
             i = 0
             while len(confirmed_reservations) == 0 and i < libcal_search_span:
                 date = now + datetime.timedelta(days=i)
-                dateStr = datetime.datetime.strftime(date, dateFormat)
+                dateStr = datetime.strftime(date, dateFormat)
                 libcal_reservations = studyspaces.get_reservations(email, dateStr, timeout)
                 confirmed_reservations = [res for res in libcal_reservations if (type(res) == dict
                                           and res['status'] == 'Confirmed'
-                                          and datetime.datetime.strptime(res['toDate'][:-6], '%Y-%m-%dT%H:%M:%S')
+                                          and datetime.strptime(res['toDate'][:-6], '%Y-%m-%dT%H:%M:%S')
                                           >= now)]
                 confirmed_reservations = [res for res in confirmed_reservations
                                           if is_not_cancelled_in_db(res['bookId'])]

--- a/server/studyspaces/reservations.py
+++ b/server/studyspaces/reservations.py
@@ -41,7 +41,7 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
     if sessionid:
         try:
             gsr_reservations = wharton.get_reservations(sessionid, timeout)
-            timezone = wharton.get_dst_gmt_timezone()
+            timezone_hours = wharton.get_dst_gmt_timezone()
 
             for res in gsr_reservations:
                 res['service'] = 'wharton'
@@ -56,9 +56,9 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                 date_str = datetime.strftime(date, '%Y-%m-%d')
 
                 if res['startTime'] == 'midnight':
-                    res['fromDate'] = date_str + 'T00:00:00-{}'.format(timezone)
+                    res['fromDate'] = date_str + 'T00:00:00-{}'.format(timezone_hours)
                 elif res['startTime'] == 'noon':
-                    res['fromDate'] = date_str + 'T12:00:00-{}'.format(timezone)
+                    res['fromDate'] = date_str + 'T12:00:00-{}'.format(timezone_hours)
                 else:
                     start_str = res['startTime'].replace('.', '').upper()
                     try:
@@ -66,14 +66,14 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                     except ValueError:
                         start_time = datetime.strptime(start_str, '%I %p')
                     start_str = datetime.strftime(start_time, '%H:%M:%S')
-                    res['fromDate'] = '{}T{}-{}'.format(date_str, start_str, timezone)
+                    res['fromDate'] = '{}T{}-{}'.format(date_str, start_str, timezone_hours)
 
                 if res['endTime'] == 'midnight':
                     date += timedelta(days=1)
                     date_str = datetime.strftime(date, '%Y-%m-%d')
-                    res['toDate'] = date_str + 'T00:00:00-{}'.format(timezone)
+                    res['toDate'] = date_str + 'T00:00:00-{}'.format(timezone_hours)
                 elif res['endTime'] == 'noon':
-                    res['toDate'] = date_str + 'T12:00:00-{}'.format(timezone)
+                    res['toDate'] = date_str + 'T12:00:00-{}'.format(timezone_hours)
                 else:
                     end_str = res['endTime'].replace('.', '').upper()
                     try:
@@ -81,7 +81,7 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                     except ValueError:
                         end_time = datetime.strptime(end_str, '%I %p')
                     end_str = datetime.strftime(end_time, '%H:%M:%S')
-                    res['toDate'] = '{}T{}-{}'.format(date_str, end_str, timezone)
+                    res['toDate'] = '{}T{}-{}'.format(date_str, end_str, timezone_hours)
 
                 del res['date']
                 del res['startTime']
@@ -99,8 +99,8 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                 booking = StudySpacesBooking.query.filter_by(booking_id=booking_id).first()
                 return not (booking and booking.is_cancelled)
 
-            est = timezone('EST')
-            now = datetime.now(est)
+            est = timezone('US/Eastern')
+            now = datetime.now(est).replace(tzinfo=None)
             dateFormat = '%Y-%m-%d'
             i = 0
             while len(confirmed_reservations) == 0 and i < libcal_search_span:

--- a/server/studyspaces/reservations.py
+++ b/server/studyspaces/reservations.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from pytz import timezone
 
 from flask import jsonify, request
@@ -69,7 +69,7 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
                     res['fromDate'] = '{}T{}-{}'.format(date_str, start_str, timezone)
 
                 if res['endTime'] == 'midnight':
-                    date += datetime.timedelta(days=1)
+                    date += timedelta(days=1)
                     date_str = datetime.strftime(date, '%Y-%m-%d')
                     res['toDate'] = date_str + 'T00:00:00-{}'.format(timezone)
                 elif res['endTime'] == 'noon':
@@ -104,7 +104,7 @@ def get_reservations(email, sessionid, libcal_search_span, timeout=20):
             dateFormat = '%Y-%m-%d'
             i = 0
             while len(confirmed_reservations) == 0 and i < libcal_search_span:
-                date = now + datetime.timedelta(days=i)
+                date = now + timedelta(days=i)
                 dateStr = datetime.strftime(date, dateFormat)
                 libcal_reservations = studyspaces.get_reservations(email, dateStr, timeout)
                 confirmed_reservations = [res for res in libcal_reservations if (type(res) == dict

--- a/server/studyspaces/reservations.py
+++ b/server/studyspaces/reservations.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
-from pytz import timezone
 
 from flask import jsonify, request
 from penn.base import APIError
+from pytz import timezone
 
 from server import app
 from server.penndata import studyspaces, wharton


### PR DESCRIPTION
Force all now datetimes to be in EST. To compare with timezone naive datetimes (those stored on the DB), we must strip `tzinfo` out. This fixes the bugs we were encountering with GSR. It also fixes uncaught bugs with the calendar and with portal. Calendar now pulls today's date as EST to look up upcoming events, and Portal compares the current time in EST with the start and end times in the DB, which are saved as EST. Lastly, this should fix GSR push notifications, which were being sent out 4 hours early.

**NOTE:** all server default dates are currently in EST. This was not affected by the deployment/server change.